### PR TITLE
Remove use_index from MDQ cURL sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,7 +1229,6 @@ curl -i -X POST "https://api.box.com/2.0/files/12345" \
          "metadata.enterprise_123456.contractTemplate.customerName"
        ],
        "ancestor_folder_id": "5555",
-       "use_index": "amountAsc",
        "order_by": [
          {
            "field_key": "amount",


### PR DESCRIPTION
Remove use_index from metadata query cURL sample as the parameter is no longer used. 