### PR TITLE
DDOC-675: Add `staticConfig` to cURL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3348,9 +3348,11 @@ curl -i -X PUT "https://api.box.com/2.0/metadata_templates/enterprise/securityCl
        "fieldKey": "Box__Security__Classification__Key",
        "data": {
          "key": "Sensitive",
-         "classification": {
-           "classificationDefinition": "Sensitive information that must not be shared.",
-           "colorID": 4
+         "staticConfig":{
+          "classification": {
+            "classificationDefinition": "Sensitive information that must not be shared.",
+            "colorID": 4
+            }
          }
        }
      }]'
@@ -3369,9 +3371,11 @@ curl -i -X PUT "https://api.box.com/2.0/metadata_templates/enterprise/securityCl
        "enumOptionKey": "Sensitive",
        "data": {
          "key": "Very Sensitive",
-         "classification": {
-           "classificationDefinition": "Sensitive information that must not be shared.",
-           "colorID": 4
+         "staticConfig": {
+           "classification": {
+            "classificationDefinition": "Sensitive information that must not be shared.",
+            "colorID": 4
+           }
          }
        }
      }]'
@@ -3416,6 +3420,7 @@ curl -i -X POST "https://api.box.com/2.0/files/12345/metadata/enterprise/securit
      -H "Content-Type: application/json" \
      -d '{
        "Box__Security__Classification__Key": "Sensitive"
+        
      }'
 ```
 


### PR DESCRIPTION
Added `staticConfig` to cURL examples for the following endpoints:

https://developer.box.com/reference/put-metadata-templates-enterprise-securityClassification-6VMVochwUWo-schema–add/
https://developer.box.com/reference/put-metadata-templates-enterprise-securityClassification-6VMVochwUWo-schema–update/