### PR TITLE
correct docgen batches sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ curl -L 'https://api.box.com/2.0/docgen_templates/12345678/tags' \
 curl -L 'https://api.box.com/2.0/docgen_batches' \
      -H 'box-version: 2025.0' \
      -H 'Authorization: Bearer <ACCESS_TOKEN>' \
-     -D '{
+     -d '{
         "file": {
             "id": "12345678",
             "type": "file"
@@ -733,8 +733,8 @@ curl -L 'https://api.box.com/2.0/docgen_batches' \
                     }
                 }
             }
-        ]`
-
+        ]
+        
 ```
 
 ## Get all Doc Gen jobs


### PR DESCRIPTION
Correct curl sample for Doc Gen batches: [Generate document using a Box Doc Gen template](https://developer.box.com/reference/v2025.0/post-docgen-batches/) 

Closes [DDOC-1250](https://jira.inside-box.net/browse/DDOC-1250)